### PR TITLE
Deployment Target is iOS 9.0, so remove the iOS 8+ branching process.

### DIFF
--- a/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
+++ b/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
@@ -535,11 +535,7 @@ static NSString *_defaultService;
 #if TARGET_OS_IOS
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
-    if (floor(NSFoundationVersionNumber) > floor(1144.17)) { // iOS 9+
-        query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
-    } else if (floor(NSFoundationVersionNumber) > floor(1047.25)) { // iOS 8+
-        query[(__bridge __strong id)kSecUseNoAuthenticationUI] = (__bridge id)kCFBooleanTrue;
-    }
+    query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
 #pragma clang diagnostic pop
 #elif TARGET_OS_WATCH || TARGET_OS_TV
     query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;


### PR DESCRIPTION
'kSecUseNoAuthenticationUI' deprecation warning.
Deployment Target is iOS 9.0, so I removed the iOS8+ process. 